### PR TITLE
Add the ability to validate modules in a namespace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,12 +49,18 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 Style/CollectionMethods:
   Enabled: true
+Style/ConditionalAssignment:
+  Enabled: false
+Style/HashSyntax:
+  Enabled: false
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
 Layout/EndOfLine:
   Enabled: false
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:

--- a/bin/dependency-checker
+++ b/bin/dependency-checker
@@ -15,8 +15,36 @@ OptionParser.new { |opts|
     options[:current_override] = current_override
   end
 
-  opts.on('-v', '--[no-]verbose', 'Run verbosely') do |verbose|
-    options[:verbose] = verbose
+  opts.on('-n', '--namespace namespace', 'Check all modules in a given namespace (filter with endorsements).') do |namespace|
+    options[:namespace] = namespace
+  end
+
+  opts.on('--endorsement endorsement', 'Filter a namespace search by endorsement (supported/approved/partner).') do |endorsement|
+    raise 'You may only filter by one endorsement at a time' if options[:endorsement]
+
+    options[:endorsement] = endorsement
+  end
+
+  opts.on('--es', '--supported', 'Shorthand for `--endorsement supported`') do
+    raise 'You may only filter by one endorsement at a time' if options[:endorsement]
+
+    options[:endorsement] = 'supported'
+  end
+
+  opts.on('--ea', '--approved', 'Shorthand for `--endorsement approved`') do
+    raise 'You may only filter by one endorsement at a time' if options[:endorsement]
+
+    options[:endorsement] = 'approved'
+  end
+
+  opts.on('--ep', '--partner', 'Shorthand for `--endorsement partner`') do
+    raise 'You may only filter by one endorsement at a time' if options[:endorsement]
+
+    options[:endorsement] = 'partner'
+  end
+
+  opts.on('-v', '--[no-]verbose', 'Run verbosely') do
+    options[:verbose] = true
   end
 
   opts.on('-h', '--help', 'Display help') do
@@ -24,13 +52,6 @@ OptionParser.new { |opts|
     exit
   end
 }.parse!
-
-# Determine which modules to pass on to runner
-managed_modules = nil
-unless ARGV.empty?
-  # If length == 1, only pass first argument, else pass the array of metadata.json files
-  managed_modules = ((ARGV.length == 1) ? ARGV[0] : ARGV)
-end
 
 # Raise error if both :override and :current_override are specified
 if options[:override] && options[:current_override]
@@ -51,4 +72,21 @@ end
 # Default :verbose to false
 options[:verbose] ||= false
 
-DependencyChecker::Runner.run_with_args(managed_modules, options[:override], options[:verbose])
+runner = DependencyChecker::Runner.new(options[:verbose])
+
+if options[:namespace]
+  runner.resolve_from_namespace(options[:namespace], options[:endorsement])
+
+elsif ARGV.empty?
+  puts "No module criteria specified. Defaulting to IAC supported modules.\n\n"
+  runner.resolve_from_path('https://puppetlabs.github.io/iac/modules.json')
+
+elsif ARGV.map { |arg| File.basename arg } != ['metadata.json']
+  runner.resolve_from_path(ARGV.first)
+
+else
+  runner.resolve_from_files(ARGV)
+end
+
+runner.override = options[:override]
+runner.run

--- a/spec/unit/runner_spec.rb
+++ b/spec/unit/runner_spec.rb
@@ -5,40 +5,66 @@ require 'dependency_checker'
 describe 'compare_dependencies' do
   managed_modules_file = File.join(File.expand_path(File.dirname(File.dirname(__FILE__))), 'fixtures/managed_modules.yaml')
   managed_modules_url = 'https://gist.githubusercontent.com/eimlav/6df50eda0b1c57c1ab8c33b64c82c336/raw/managed_modules_test.yaml'
-  module_name = 'puppetlabs-stdlib'
-  version = '10.0.0'
+  # module_name = 'puppetlabs-stdlib'
+  # version = '10.0.0'
   verbose = false
 
-  context 'run executable with valid arguments' do
+  context 'run executable with namespace' do
     it 'is expected to run without errors' do
-      expect { DependencyChecker::Runner.run_with_args(managed_modules_file, [module_name, version], verbose) }.not_to raise_error
+      expect {
+        runner = DependencyChecker::Runner.new(verbose)
+        runner.resolve_from_namespace('puppetlabs', 'supported')
+        runner.run
+      }.not_to raise_error
     end
   end
 
-  context 'run executable with mandatory arguments: managed_modules, module_name, version, verbose' do
-    it 'is expected to run without error' do
-      expect { DependencyChecker::Runner.run_with_args(managed_modules_file, [module_name, version], verbose) }.not_to raise_error
+  context 'run executable with list of modules' do
+    it 'when passed a file of modules' do
+      expect {
+        runner = DependencyChecker::Runner.new(verbose)
+        runner.resolve_from_path(managed_modules_file)
+        runner.run
+      }.not_to raise_error
     end
 
-    it 'is expected to run without error when managed_modules is a valid URL' do
-      expect { DependencyChecker::Runner.run_with_args(managed_modules_url, [module_name, version], verbose) }.not_to raise_error
+    it 'when passed a url with modules' do
+      expect {
+        runner = DependencyChecker::Runner.new(verbose)
+        runner.resolve_from_path(managed_modules_url)
+        runner.run
+      }.not_to raise_error
     end
   end
 
   context 'run executable with invalid arguments' do
     it 'is expected to raise an error when managed_modules is not found' do
-      error_message = '*Error:* Ensure *invalid path* is a valid file path or URL'
-      expect { DependencyChecker::Runner.run_with_args('invalid path', ['puppetlabs-stdlib', '1.0.0'], verbose) }.to raise_error(RuntimeError, error_message)
+      error_message = '*Error:* Ensure *invalid_path* is a valid file path or URL'
+      expect {
+        runner = DependencyChecker::Runner.new(verbose)
+        runner.resolve_from_path('invalid_path')
+        runner.run
+      }.to raise_error(RuntimeError, error_message)
     end
 
     it 'is expected to raise an error when module name could not be found in the Forge' do
       error_message = '*Error:* Could not find *invalid_name* on Puppet Forge! Ensure updated_module argument is valid.'
-      expect { DependencyChecker::Runner.run_with_args(managed_modules_file, ['invalid_name', '1.0.0'], verbose) }.to raise_error(RuntimeError, error_message)
+      expect {
+        runner = DependencyChecker::Runner.new(verbose)
+        runner.resolve_from_path(managed_modules_file)
+        runner.override = ['invalid_name', '1.0.0']
+        runner.run
+      }.to raise_error(RuntimeError, error_message)
     end
 
     it 'is expected to raise an error when version has an invalid syntax' do
       error_message = '*Error:* Verify semantic versioning syntax *1.00* of updated_module_version argument.'
-      expect { DependencyChecker::Runner.run_with_args(managed_modules_file, ['puppetlabs-stdlib', '1.00'], verbose) }.to raise_error(RuntimeError, error_message)
+      expect {
+        runner = DependencyChecker::Runner.new(verbose)
+        runner.resolve_from_path(managed_modules_file)
+        runner.override = ['puppetlabs-stdlib', '1.00']
+        runner.run
+      }.to raise_error(RuntimeError, error_message)
     end
   end
 end


### PR DESCRIPTION
This adds a few ways to specify modules to validate.

* It now defaults to the IAC supported module list instead of @eimlav's gist.
* It adds a --namespace argument to validate all modules in a namspace
* You can filter that search by supported/approved/partner
* Now supports YAML and JSON module lists both

It also cleans up a small bit of logic and corrects some incorrect
yarddoc comments. The specs could use some improvements.

This shouldn't change existing behaviour, but that was hard to validate
because I couldn't find examples to compare to. Everything I could infer
is roughly equivalent behaviour.