### PR TITLE
Report status with exit-code

### DIFF
--- a/bin/dependency-checker
+++ b/bin/dependency-checker
@@ -90,3 +90,5 @@ end
 
 runner.override = options[:override]
 runner.run
+
+exit(runner.problems.zero? ? 0 : 1)

--- a/lib/dependency_checker/runner.rb
+++ b/lib/dependency_checker/runner.rb
@@ -8,6 +8,8 @@ require 'parallel'
 
 # Main runner for DependencyChecker
 class DependencyChecker::Runner
+  attr_reader :problems
+
   def initialize(verbose = false)
     @forge   = DependencyChecker::ForgeHelper.new
     @verbose = verbose
@@ -44,6 +46,7 @@ class DependencyChecker::Runner
 
     # Post results of dependency checks
     message = run_dependency_checks
+    @problems = message.size
     message = 'All modules have valid dependencies.' if message.empty?
 
     post(message)


### PR DESCRIPTION
Only return 0 when no dependency is outdated.  If some dependency is
outdated, exit with 1.

This makes it easier to script dependency-checker to automate modules
management.