### PR TITLE
(GH-30) Add Forge hostname and auth token params

### DIFF
--- a/bin/dependency-checker
+++ b/bin/dependency-checker
@@ -43,6 +43,16 @@ OptionParser.new { |opts|
     options[:endorsement] = 'partner'
   end
 
+  opts.on('--ft forge_token', '--forge-token forge_token', 'The API token to authenticate the Forge connection with') do |forge_token|
+    options[:forge_token] = forge_token
+  end
+
+  opts.on('--fh forge_hostname', '--forge-hostname forge_hostname', 'Specify a specific Forge hostname to overwrite the default of https://forgeapi.puppet.com') do |forge_hostname|
+    raise 'Forge host must be specified in the format https://your-own-api.url/' unless forge_hostname.start_with? 'http'
+
+    options[:forge_hostname] = forge_hostname
+  end
+
   opts.on('-v', '--[no-]verbose', 'Run verbosely') do
     options[:verbose] = true
   end
@@ -72,7 +82,7 @@ end
 # Default :verbose to false
 options[:verbose] ||= false
 
-runner = DependencyChecker::Runner.new(options[:verbose])
+runner = DependencyChecker::Runner.new(options[:verbose], options[:forge_hostname], options[:forge_token])
 
 if options[:namespace]
   runner.resolve_from_namespace(options[:namespace], options[:endorsement])

--- a/lib/dependency_checker/forge_helper.rb
+++ b/lib/dependency_checker/forge_helper.rb
@@ -5,8 +5,10 @@ require 'semantic_puppet'
 
 # Helper class for fetching data from the Forge and perform some basic operations
 class DependencyChecker::ForgeHelper
-  def initialize(cache = {})
+  def initialize(cache = {}, forge_hostname = nil, forge_token = nil)
     @cache = cache
+    PuppetForge.host = forge_hostname unless forge_hostname.nil?
+    PuppetForge::Connection.authorization = forge_token unless forge_token.nil?
   end
 
   # Retrieve current version of module

--- a/lib/dependency_checker/runner.rb
+++ b/lib/dependency_checker/runner.rb
@@ -10,8 +10,8 @@ require 'parallel'
 class DependencyChecker::Runner
   attr_reader :problems
 
-  def initialize(verbose = false)
-    @forge   = DependencyChecker::ForgeHelper.new
+  def initialize(verbose = false, forge_hostname = nil, forge_token = nil)
+    @forge   = DependencyChecker::ForgeHelper.new({}, forge_hostname, forge_token)
     @verbose = verbose
   end
 


### PR DESCRIPTION
Prior to this commit, there was no ability to specify a custom
Forge URI and/or authentication token. This would impact users who
either had their own Forge instance, were premium content users or
both.

This commit adds the `--forge-hostname` and `--forge-token` opts
to the CLI and passes these to `PuppetForge` on initialisation, if
defined.

Resolves: #30 