### PR TITLE
(CONT-693) - Implement reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: "ci"
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+
+  spec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - '2.5'
+          - '2.7'
+    name: "spec (ruby ${{ matrix.ruby_version }})"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
+    secrets: "inherit"
+    with:
+      ruby_version: ${{ matrix.ruby_version }}

--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,0 +1,22 @@
+name: community-labeller
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: puppetlabs/community-labeller@v0
+        name: Label issues or pull requests
+        with:
+          label_name: community
+          label_color: '5319e7'
+          org_membership: puppetlabs
+          token: ${{ secrets.IAC_COMMUNITY_LABELER }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,22 @@
+name: "ci"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+
+  spec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - '2.5'
+          - '2.7'
+    name: "spec (ruby ${{ matrix.ruby_version }})"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
+    secrets: "inherit"
+    with:
+      ruby_version: ${{ matrix.ruby_version }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: "Release"
+
+on:
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "main"
+
+jobs:
+  release:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+    secrets: "inherit"

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -1,0 +1,20 @@
+name: "Release Prep"
+
+on:
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "main"
+    version:
+      description: "Version of gem to be released."
+      required: true
+
+jobs:
+  release_prep:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release_prep.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+      version: "${{ github.event.inputs.version }}"
+    secrets: "inherit"

--- a/Rakefile
+++ b/Rakefile
@@ -1,26 +1,5 @@
-require 'github_changelog_generator/task'
+require 'rspec/core/rake_task'
 
-GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-  config.user = 'puppetlabs'
-  config.project = 'dependency_checker'
-  config.future_release = '0.3.0'
-  config.exclude_labels = ['maintenance']
-  config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-  config.add_pr_wo_labels = true
-  config.issues = false
-  config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
-  config.configure_sections = {
-    "Changed" => {
-      "prefix" => "### Changed",
-      "labels" => ["backwards-incompatible"],
-    },
-    "Added" => {
-      "prefix" => "### Added",
-      "labels" => ["feature", "enhancement"],
-    },
-    "Fixed" => {
-      "prefix" => "### Fixed",
-      "labels" => ["bugfix"],
-    },
-  }
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.exclude_pattern = 'spec/acceptance/**/*_spec.rb'
 end

--- a/dependency_checker.gemspec
+++ b/dependency_checker.gemspec
@@ -1,6 +1,10 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'dependency_checker/version'
+
 Gem::Specification.new do |s|
   s.name        = 'dependency_checker'
-  s.version     = '0.3.0'
+  s.version     = DependencyChecker::VERSION
   s.executables << 'dependency-checker'
   s.licenses    = ['MIT']
   s.summary     = 'Check your Puppet metadata dependencies'

--- a/lib/dependency_checker/version.rb
+++ b/lib/dependency_checker/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module DependencyChecker
+  VERSION = '0.3.0'
+end


### PR DESCRIPTION
Prior to this PR, the version of the gem would need to be manually updated, pushed and merged into main each time before running release_prep.yml.

This PR introduces a "version" input parameter, that can be specified when running the workflow which eliminates the need for the above.

The PR also introduces the cat team reusable workflows.