### PR TITLE
(CAT-1307) -  Fix broken CAT default module dependency check

### DIFF
--- a/bin/dependency-checker
+++ b/bin/dependency-checker
@@ -19,12 +19,6 @@ OptionParser.new do |opts|
     options[:namespace] = namespace
   end
 
-  opts.on('-b bolt_project', '--bolt-project bolt_project', 'Check all modules within a bolt-project.yaml file.') do |bolt_project|
-    raise 'You must specify a valid bolt-project.yaml' unless File.exist?(bolt_project) || bolt_project.end_with?('.yaml')
-    
-    options[:bolt_project] = bolt_project
-  end
-
   opts.on('--endorsement endorsement', 'Filter a namespace search by endorsement (supported/approved/partner).') do |endorsement|
     raise 'You may only filter by one endorsement at a time' if options[:endorsement]
 

--- a/bin/dependency-checker
+++ b/bin/dependency-checker
@@ -19,6 +19,12 @@ OptionParser.new do |opts|
     options[:namespace] = namespace
   end
 
+  opts.on('-b bolt_project', '--bolt-project bolt_project', 'Check all modules within a bolt-project.yaml file.') do |bolt_project|
+    raise 'You must specify a valid bolt-project.yaml' unless File.exist?(bolt_project) || bolt_project.end_with?('.yaml')
+    
+    options[:bolt_project] = bolt_project
+  end
+
   opts.on('--endorsement endorsement', 'Filter a namespace search by endorsement (supported/approved/partner).') do |endorsement|
     raise 'You may only filter by one endorsement at a time' if options[:endorsement]
 
@@ -86,8 +92,8 @@ if options[:namespace]
   runner.resolve_from_namespace(options[:namespace], options[:endorsement])
 
 elsif ARGV.empty?
-  puts "No module criteria specified. Defaulting to IAC supported modules.\n\n"
-  runner.resolve_from_path('https://puppetlabs.github.io/iac/modules.json')
+  puts "No module criteria specified. Defaulting to CAT supported modules.\n\n"
+  runner.resolve_from_path('https://puppetlabs.github.io/content-and-tooling-team/modules/list.json')
 
 elsif ARGV.map { |arg| File.basename arg } != ['metadata.json']
   runner.resolve_from_path(ARGV.first)

--- a/lib/dependency_checker/runner.rb
+++ b/lib/dependency_checker/runner.rb
@@ -8,7 +8,7 @@ require 'parallel'
 
 # Main runner for DependencyChecker
 module DependencyChecker
-  class Runner
+  class Runner # rubocop:disable Metrics/ClassLength
     attr_reader :problems
 
     def initialize(verbose = false, forge_hostname = nil, forge_token = nil)
@@ -184,10 +184,12 @@ module DependencyChecker
         raise "*Error:* Ensure syntax of #{path} file is valid YAML or JSON"
       end
 
-      # transform from IAC supported module hash to simple list
-      modules = modules.filter_map { |_key, val| val['puppet_module'] } if modules.is_a? Hash
-
-      modules
+      # transform from CAT supported module hash to simple list
+      if path.end_with? '/content-and-tooling-team/modules/list.json'
+        modules.filter_map { |key, _val| key['name'] } if modules.is_a? Array
+      elsif modules.is_a? Hash
+        modules.filter_map { |_key, val| val['puppet_module'] }
+      end
     end
 
     # Post message to terminal


### PR DESCRIPTION
## Summary
When no path supplied to a module's `metadata.json`, the dependency_checker would default to checking the CAT supported modules dependencies.
Due to the difference in formatting of the modules JSON list between the legacy IAC site and the new CAT Team site, the logic here needed updated in order to work.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
