### PR TITLE
(maint) Remove the error avoidance hack by RuboCop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :test do
   gem 'simplecov', require: false
   gem 'simplecov-console', require: false
   gem 'rspec', '~> 3.0', require: false
-  gem 'rubocop', '~> 1.50.0', require: false
+  gem 'rubocop', '~> 1.64.0', require: false
   gem 'rubocop-performance', '~> 1.16', require: false
   gem 'rubocop-rspec', '~> 2.19', require: false
   gem 'rubocop-factory_bot', '!= 2.26.0', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,4 @@ group :test do
   gem 'rubocop', '~> 1.64.0', require: false
   gem 'rubocop-performance', '~> 1.16', require: false
   gem 'rubocop-rspec', '~> 3.0', require: false
-  gem 'rubocop-factory_bot', '!= 2.26.0', require: false
-  gem 'rubocop-rspec_rails', '!= 2.29.0', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :test do
   gem 'rspec', '~> 3.0', require: false
   gem 'rubocop', '~> 1.64.0', require: false
   gem 'rubocop-performance', '~> 1.16', require: false
-  gem 'rubocop-rspec', '~> 2.19', require: false
+  gem 'rubocop-rspec', '~> 3.0', require: false
   gem 'rubocop-factory_bot', '!= 2.26.0', require: false
   gem 'rubocop-rspec_rails', '!= 2.29.0', require: false
 end


### PR DESCRIPTION
## Summary
This PR remove the error avoidance hack by RuboCop version.

## Additional Context

With the following release, the hack by the RuboCop version is no longer necessary. Therefore, it is removed.
To add this support, rubocop must be v1.61 or higher and rubocop-rspec must be v3.0.1 or higher.
https://github.com/rubocop/rubocop-rspec/releases/tag/v3.0.1

## Related Issues (if any)
Mention any related issues or pull requests.

- https://github.com/puppetlabs/dependency_checker/pull/72

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified.

No error:
```
❯ bundle exec rubocop -V
1.64.1 (using Parser 3.3.2.0, rubocop-ast 1.31.3, running on ruby 3.3.0) [arm64-darwin23]
  - rubocop-performance 1.21.0
  - rubocop-rspec 3.0.1
```
