### PR TITLE
(CAT-2281) Remove puppet 7 test infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby_version:
-          - '2.7'
           - '3.2'
     name: "spec (ruby ${{ matrix.ruby_version }})"
     uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,5 +13,4 @@ AllCops:
     - vendor/bundle/**/*
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: '2.7'
-
+  TargetRubyVersion: '3.1'

--- a/dependency_checker.gemspec
+++ b/dependency_checker.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/puppetlabs/dependency_checker',
     'rubygems_mfa_required' => 'true'
   }
-  s.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
+  s.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 
   s.add_runtime_dependency 'parallel'
   s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 6.0'


### PR DESCRIPTION
Puppet 7 is EOL. Therefore, we can remove the test infrastructure for it. This commit aims to clear up any testing/config infrastructure related to Puppet 7 and, by extension, Ruby 2.7.