### PR TITLE
(maint) consider puppet-forge dependency to include 6.0 version

### DIFF
--- a/dependency_checker.gemspec
+++ b/dependency_checker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 
   s.add_runtime_dependency 'parallel'
-  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 6.0'
+  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '<= 6.0'
   s.add_runtime_dependency 'rake', '~> 13.0'
   s.add_runtime_dependency 'semantic_puppet', '~> 1.0'
 end


### PR DESCRIPTION
updating dependency checker for considering puppet-forge version 6.0