### PR TITLE
(maint) Allow puppet_forge 6

### DIFF
--- a/dependency_checker.gemspec
+++ b/dependency_checker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 
   s.add_runtime_dependency 'parallel'
-  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 6.0'
+  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 7.0'
   s.add_runtime_dependency 'rake', '~> 13.0'
   s.add_runtime_dependency 'semantic_puppet', '~> 1.0'
 end


### PR DESCRIPTION
This commit updates dependency_checker's runtime dependency on the puppet_forge gem to allow the latest major version of puppet_forge, version 6.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
