### PR TITLE
Update expected stdlib dependency range to match puppetlabs-motd metadata

### DIFF
--- a/spec/unit/metadata_checker_spec.rb
+++ b/spec/unit/metadata_checker_spec.rb
@@ -17,7 +17,7 @@ describe 'dependency_checker' do
         [
           ['puppetlabs/registry', SemanticPuppet::VersionRange.parse('>=1.0.0 <6.0.0'),
            SemanticPuppet::Version.parse('5.0.3'), true],
-          ['puppetlabs/stdlib', SemanticPuppet::VersionRange.parse('>=2.1.0 <10.0.0'),
+          ['puppetlabs/stdlib', SemanticPuppet::VersionRange.parse('>=2.1.0 <11.0.0'),
            SemanticPuppet::Version.parse('9.3.0'), true]
         ]
       )


### PR DESCRIPTION
## Problem

The nightly `spec` job has started failing on `main` (e.g. [run 29790742951](https://github.com/puppetlabs/dependency_checker/actions/runs/29790742951)) with a single failing example:

```
spec/unit/metadata_checker_spec.rb:15
  dependency_checker check_dependencies method returns correct results
```

```
expected: [..., ["puppetlabs/stdlib", >=2.1.0 <10.0.0, 9.3.0, true]]
     got: [..., ["puppetlabs/stdlib", >=2.1.0 <11.0.0, 9.3.0, true]]
```

The test fetches `puppetlabs-motd`'s current release metadata **live from the Forge** (`spec/unit/metadata_checker_spec.rb:9`) and asserts its declared dependency ranges. `puppetlabs-motd` (now v8.0.0) has bumped its stdlib upper bound from `< 10.0.0` to `< 11.0.0`, so the live metadata no longer matches the hardcoded expectation. No code changed — an upstream module's dependency update tripped the assertion.

## Fix

Update the expected range to match motd's current metadata:

```diff
-['puppetlabs/stdlib', SemanticPuppet::VersionRange.parse('>=2.1.0 <10.0.0'), ...]
+['puppetlabs/stdlib', SemanticPuppet::VersionRange.parse('>=2.1.0 <11.0.0'), ...]
```

Verified against the live Forge (motd 8.0.0 → `stdlib >= 2.1.0 < 11.0.0`, `registry >= 1.0.0 < 6.0.0`, registry latest `5.0.3`) and the spec passes locally.

## Follow-up (not in this PR)

This is a stop-gap. The test asserts hardcoded values against **live Forge data** (`puppetlabs-motd` metadata + `puppetlabs-registry` latest version), so it will keep breaking whenever those upstream modules publish changes — this is the same class of nightly fragility as puppet_litmus. The durable fix is to stub the Forge responses with a fixture so the test is hermetic. Happy to raise that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)